### PR TITLE
Add max() genSequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ const setOf4LetterWords = new Set(genSequence(setOfWords).filter(a => a.length =
 - `.any()` -- true if any value in the sequence exists where *fn(value)* returns true.
 - `.first()` -- return the next value in the sequence.
 - `.first(fn)` -- return the next value in the sequence where *fn(value)* return true.
+- `.max()` -- return the largest value in the sequence. Throws and Error if the sequence is empty.
 
 ### Misc
 - `toIterable()` -- Casts a Sequence into an IterableIterator - used in cases where type checking is too strict.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ const setOf4LetterWords = new Set(genSequence(setOfWords).filter(a => a.length =
 - `.any()` -- true if any value in the sequence exists where *fn(value)* returns true.
 - `.first()` -- return the next value in the sequence.
 - `.first(fn)` -- return the next value in the sequence where *fn(value)* return true.
-- `.max()` -- return the largest value in the sequence. Throws and Error if the sequence is empty.
+- `.max()` -- return the largest value in the sequence.
+- `.max(fn)` -- return the largest value returned by *fn(value)* in the sequence.
 
 ### Misc
 - `toIterable()` -- Casts a Sequence into an IterableIterator - used in cases where type checking is too strict.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const setOf4LetterWords = new Set(genSequence(setOfWords).filter(a => a.length =
 - `.first()` -- return the next value in the sequence.
 - `.first(fn)` -- return the next value in the sequence where *fn(value)* return true.
 - `.max()` -- return the largest value in the sequence.
-- `.max(fn)` -- return the largest value returned by *fn(value)* in the sequence.
+- `.max(fn)` -- return the largest value of *fn(value)* in the sequence.
 
 ### Misc
 - `toIterable()` -- Casts a Sequence into an IterableIterator - used in cases where type checking is too strict.

--- a/src/GenSequence.test.ts
+++ b/src/GenSequence.test.ts
@@ -318,9 +318,9 @@ describe('GenSequence Tests', function() {
         expect(genSequence(values).max()).to.equal(4);
     });
 
-    it('test max throws on empty set', () => {
+    it('test max on empty set returns undefined', () => {
         const values = [];
-        expect(() => genSequence(values).max()).to.throw(Error);
+        expect(genSequence(values).max()).to.be.undefined
     });
 
     it('test max on string values', () => {
@@ -339,8 +339,13 @@ describe('GenSequence Tests', function() {
         expect(genSequence(values).max()).to.equal(bigger);
     });
 
+    it('test max starts with undefined always undefined', () => {
+        const values = [undefined, 1, undefined, 2];
+        expect(genSequence(values).max()).to.be.undefined;
+    });
+
     it('test max undefined value', () => {
-        const values = [undefined, 1, undefined, 2, undefined];
+        const values = [1, undefined, 2, undefined];
         expect(genSequence(values).max()).to.equal(2);
     });
 
@@ -349,23 +354,42 @@ describe('GenSequence Tests', function() {
         expect(genSequence(values).max()).to.equal(2);
     });
 
-    it('test max NaN value', () => {
+    it('test max starts with NaN always NaN', () => {
         const values = [NaN, 1, NaN, 2];
+        expect(genSequence(values).max()).to.be.NaN;
+    });
+
+    it('test max NaN value', () => {
+        const values = [1, NaN, 2];
         expect(genSequence(values).max()).to.equal(2);
     });
 
     it('test max all undefined value', () => {
         const values = [undefined, undefined];
-        expect(genSequence(values).max()).to.equal(undefined);
+        expect(genSequence(values).max()).to.be.undefined;
     });
 
     it('test max all null value', () => {
         const values = [null, null];
-        expect(genSequence(values).max()).to.equal(undefined);
+        expect(genSequence(values).max()).to.be.null;
     });
 
     it('test max all NaN value', () => {
         const values = [NaN, NaN];
-        expect(genSequence(values).max()).to.equal(undefined);
+        expect(genSequence(values).max()).to.be.NaN;
+    });
+
+    it('test max with selector', () => {
+        const one: any = {
+            age: 1,
+            animal: "zebra"
+        };
+        const two: any = {
+            age: 2,
+            animal: "alligator"
+        };
+        const values = [one, two];
+        expect(genSequence(values).max((v) => v.age)).to.equal(two);
+        expect(genSequence(values).max((v) => v.animal)).to.equal(one);
     });
 });

--- a/src/GenSequence.test.ts
+++ b/src/GenSequence.test.ts
@@ -297,4 +297,75 @@ describe('GenSequence Tests', function() {
         });
         expect(count).to.be.equal(3);
     });
+
+    it('test max on single value', () => {
+        const values = [2];
+        expect(genSequence(values).max()).to.equal(2);
+    });
+
+    it('test max returns max on start', () => {
+        const values = [4, 3, 2, 1];
+        expect(genSequence(values).max()).to.equal(4);
+    });
+
+    it('test max returns max in middle', () => {
+        const values = [1, 3, 1];
+        expect(genSequence(values).max()).to.equal(3);
+    });
+
+    it('test max returns max on end', () => {
+        const values = [1, 2, 3, 4];
+        expect(genSequence(values).max()).to.equal(4);
+    });
+
+    it('test max throws on empty set', () => {
+        const values = [];
+        expect(() => genSequence(values).max()).to.throw(Error);
+    });
+
+    it('test max on string values', () => {
+        const values = ["one", "two"];
+        expect(genSequence(values).max()).to.equal("two");
+    });
+
+    it('test max on object values', () => {
+        const smaller: any = {
+            valueOf: function() { return 1; }
+        };
+        const bigger: any = {
+            valueOf: function() { return 2; }
+        };
+        const values = [smaller, bigger];
+        expect(genSequence(values).max()).to.equal(bigger);
+    });
+
+    it('test max undefined value', () => {
+        const values = [undefined, 1, undefined, 2, undefined];
+        expect(genSequence(values).max()).to.equal(2);
+    });
+
+    it('test max null value', () => {
+        const values = [null, 1, null, 2];
+        expect(genSequence(values).max()).to.equal(2);
+    });
+
+    it('test max NaN value', () => {
+        const values = [NaN, 1, NaN, 2];
+        expect(genSequence(values).max()).to.equal(2);
+    });
+
+    it('test max all undefined value', () => {
+        const values = [undefined, undefined];
+        expect(genSequence(values).max()).to.equal(undefined);
+    });
+
+    it('test max all null value', () => {
+        const values = [null, null];
+        expect(genSequence(values).max()).to.equal(undefined);
+    });
+
+    it('test max all NaN value', () => {
+        const values = [NaN, NaN];
+        expect(genSequence(values).max()).to.equal(undefined);
+    });
 });

--- a/src/GenSequence.ts
+++ b/src/GenSequence.ts
@@ -287,9 +287,8 @@ export function first<T>(fn: (t: T) => boolean, defaultValue: T, i: Iterable<T>)
     return defaultValue;
 }
 
-export function max<T, U>(fn: (t: T) => U, i: Iterable<T>): Maybe<T>;
-export function max<T>(fn: Maybe<(t: T) => T>, i: Iterable<T>): Maybe<T> {
-    const selector = fn || ((v) => v);
+export function max<T, U>(selector: (t: T) => U, i: Iterable<T>): Maybe<T>;
+export function max<T>(selector: (t: T) => T = (t => t), i: Iterable<T>): Maybe<T> {
     return reduce((p: T, c: T) => selector(c) > selector(p) ? c : p, undefined, i);
 }
 


### PR DESCRIPTION
I normalized all the non-values (null, NaN, and undefined) to be undefined so I can return them as a part of Maybe<T>.

MDN shows the behavior of Array.prototype.reduce throws an Error when the set is empty.  I notice the reduce in this library doesn't do that, but I implemented  it to get your thoughts on it.

I struggled to figure out where to put the method in the list of methods.  I ended up putting it next to other methods that don't take parameters.  That doesn't seem like a great choice but I didn't see a better pattern.  I wonder if we should alphabetize them all instead?