### PR TITLE
Add min operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ const setOf4LetterWords = new Set(genSequence(setOfWords).filter(a => a.length =
 - `.first(fn)` -- return the next value in the sequence where *fn(value)* return true.
 - `.max()` -- return the largest value in the sequence.
 - `.max(fn)` -- return the largest value of *fn(value)* in the sequence.
+- `.min()` -- return the smallest value in the sequence.
+- `.min(fn)` -- return the smallest value of *fn(value)* in the sequence.
 
 ### Misc
 - `toIterable()` -- Casts a Sequence into an IterableIterator - used in cases where type checking is too strict.

--- a/src/GenSequence.test.ts
+++ b/src/GenSequence.test.ts
@@ -392,4 +392,99 @@ describe('GenSequence Tests', function() {
         expect(genSequence(values).max((v) => v.age)).to.equal(two);
         expect(genSequence(values).max((v) => v.animal)).to.equal(one);
     });
+
+    it('test min on single value', () => {
+        const values = [2];
+        expect(genSequence(values).min()).to.equal(2);
+    });
+
+    it('test min returns min on start', () => {
+        const values = [1, 2, 3, 4];
+        expect(genSequence(values).min()).to.equal(1);
+    });
+
+    it('test min returns min in middle', () => {
+        const values = [3, 1, 3];
+        expect(genSequence(values).min()).to.equal(1);
+    });
+
+    it('test min returns min on end', () => {
+        const values = [4, 3, 2, 1];
+        expect(genSequence(values).min()).to.equal(1);
+    });
+
+    it('test min on empty set returns undefined', () => {
+        const values = [];
+        expect(genSequence(values).min()).to.be.undefined
+    });
+
+    it('test min on string values', () => {
+        const values = ["one", "two"];
+        expect(genSequence(values).min()).to.equal("one");
+    });
+
+    it('test min on object values', () => {
+        const smaller: any = {
+            valueOf: function() { return 1; }
+        };
+        const bigger: any = {
+            valueOf: function() { return 2; }
+        };
+        const values = [smaller, bigger];
+        expect(genSequence(values).min()).to.equal(smaller);
+    });
+
+    it('test min starts with undefined always undefined', () => {
+        const values = [undefined, 1, undefined, 2];
+        expect(genSequence(values).min()).to.be.undefined;
+    });
+
+    it('test min undefined value', () => {
+        const values = [2, undefined, 1, undefined];
+        expect(genSequence(values).min()).to.equal(1);
+    });
+
+    it('test min null value', () => {
+        const values = [null, 1, null, 2];
+        expect(genSequence(values).min()).to.be.null;
+    });
+
+    it('test min starts with NaN always NaN', () => {
+        const values = [NaN, 1, NaN, 2];
+        expect(genSequence(values).min()).to.be.NaN;
+    });
+
+    it('test min NaN value', () => {
+        const values = [1, NaN, 2];
+        expect(genSequence(values).min()).to.equal(1);
+    });
+
+    it('test min all undefined value', () => {
+        const values = [undefined, undefined];
+        expect(genSequence(values).min()).to.be.undefined;
+    });
+
+    it('test min all null value', () => {
+        const values = [null, null];
+        expect(genSequence(values).min()).to.be.null;
+    });
+
+    it('test min all NaN value', () => {
+        const values = [NaN, NaN];
+        expect(genSequence(values).min()).to.be.NaN;
+    });
+
+    it('test min with selector', () => {
+        const one: any = {
+            age: 1,
+            animal: "zebra"
+        };
+        const two: any = {
+            age: 2,
+            animal: "alligator"
+        };
+        const values = [one, two];
+        expect(genSequence(values).min((v) => v.age)).to.equal(one);
+        expect(genSequence(values).min((v) => v.animal)).to.equal(two);
+    });
 });

--- a/src/GenSequence.ts
+++ b/src/GenSequence.ts
@@ -29,6 +29,8 @@ export interface Sequence<T> extends IterableLike<T> {
     first(fnFilter: (t: T)=> boolean, defaultValue: T): T;
     max(fnSelector?: (t: T) => T): Maybe<T>;
     max<U>(fnSelector: (t: T) => U): Maybe<T>;
+    min(fnSelector?: (t: T) => T): Maybe<T>;
+    min<U>(fnSelector: (t: T) => U): Maybe<T>;
     toArray(): T[];
     toIterable(): IterableIterator<T>;
 }
@@ -91,6 +93,9 @@ export function genSequence<T>(i: GenIterable<T>): Sequence<T> {
         },
         max: <U>(fnSelector: (t: T) => U): Maybe<T> =>  {
             return max<T, U>(fnSelector, i);
+        },
+        min: <U>(fnSelector: (t: T) => U): Maybe<T> =>  {
+            return min<T, U>(fnSelector, i);
         },
         toArray: () => [...i],
         toIterable: () => {
@@ -290,6 +295,11 @@ export function first<T>(fn: (t: T) => boolean, defaultValue: T, i: Iterable<T>)
 export function max<T, U>(selector: (t: T) => U, i: Iterable<T>): Maybe<T>;
 export function max<T>(selector: (t: T) => T = (t => t), i: Iterable<T>): Maybe<T> {
     return reduce((p: T, c: T) => selector(c) > selector(p) ? c : p, undefined, i);
+}
+
+export function min<T, U>(selector: (t: T) => U, i: Iterable<T>): Maybe<T>;
+export function min<T>(selector: (t: T) => T = (t => t), i: Iterable<T>): Maybe<T> {
+    return reduce((p: T, c: T) => selector(c) < selector(p) ? c : p, undefined, i);
 }
 
 export function* toIterator<T>(i: Iterable<T>) {


### PR DESCRIPTION
Just a copy of max with the greater than switched to less than.  

One interesting difference the tests pointed out is that max kind of works with nulls

```javascript
expext(genSequence([null, 1, null, 2]).max()).to.equal(2)
```
where the min doesn't because null is compared a lot like zero.
```javascript
expext(genSequence([null, 1, null, 2]).min()).to.be.null
```

I think that is fine because we were saying that users should filter out items they don't want included in the operation.

