### PR TITLE
Upgrade to typescript 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nyc": "^10.1.2",
     "rimraf": "^2.5.4",
     "ts-node": "^2.1.0",
-    "typescript": "^2.3.2"
+    "typescript": "^2.4.2"
   },
   "scripts": {
     "prepublish": "npm run clean-build && npm test",

--- a/src/GenSequence.ts
+++ b/src/GenSequence.ts
@@ -22,8 +22,8 @@ export interface Sequence<T> extends IterableLike<T> {
     /** map values from type T to type U */
     combine<U, V>(fn: (t: T, u?: U) => V, j: Iterable<U>): Sequence<V>;
     map<U>(fnMap: (t: T) => U): Sequence<U>;
-    scan(fnReduce: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): Sequence<T>;
-    scan<U>(fnReduce: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): Sequence<U>;
+    scan(fnReduce: (previousValue: T, currentValue: T, currentIndex: number) => T, initialValue?: T): Sequence<T>;
+    scan<U>(fnReduce: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): Sequence<U>;
 
     //// Reducers
     all(fnFilter: (t: T)=> boolean): boolean;


### PR DESCRIPTION
Fix an issue that was blocking us from using GenSequence with typescript 2.4.