### PR TITLE
Create reduce async

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ const setOf4LetterWords = new Set(genSequence(setOfWords).filter(a => a.length =
 - `.min()` -- return the smallest value in the sequence.
 - `.min(fn)` -- return the smallest value of *fn(value)* in the sequence.
 - `.reduce(fn, init?)` -- just like array.reduce, reduces the sequence into a single result.
+- `.reduceAsync(fn, init?)` -- just like array.reduce, reduces promises into the sequence into a single result chaining the promises, fn/init can be async or not, it will work, the previousValue, and currentValue will never be a promise.
 - `.reduceToSequence(fn, init)` -- return a sequence of values that *fn* creates from looking at all the values and the initial sequence.
 
 ### Cast

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ const setOf4LetterWords = new Set(genSequence(setOfWords).filter(a => a.length =
 ### Mappers
 - `.combine(fnCombiner, iterable)` -- is used to combine values from two different lists.
 - `.map(fn)` -- just like array.map, allows you to convert the values in a sequence.
+- `.pipe(...operatorFns)` -- pipe any amount of operators in sequence.
 - `.scan(fn, init?)` -- similar to reduce, but returns a sequence of all the results of fn.
 
 ### Reducers

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,5 +19,6 @@ module.exports = {
         "node"
     ],
     "moduleNameMapper": {
-    }
+    },
+    "coverageReporters": ["json", "lcov", "text", "clover", "html"]
 }

--- a/package.json
+++ b/package.json
@@ -56,24 +56,5 @@
   "bugs": {
     "url": "https://github.com/Jason3S/GenSequence/issues"
   },
-  "nyc": {
-    "include": [
-      "src/**/*.ts"
-    ],
-    "exclude": [
-      "src/**/*.test.ts",
-      "src/**/*.perf.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
-    ],
-    "reporter": [
-      "json",
-      "html"
-    ]
-  },
   "homepage": "https://github.com/Jason3S/GenSequence#readme"
 }

--- a/src/AsyncGenSequence.test.ts
+++ b/src/AsyncGenSequence.test.ts
@@ -1,0 +1,42 @@
+import { asyncGenSequence } from './AsyncGenSequence';
+
+describe('AsyncGenSequence Tests', () => {
+    test('tests reducing asynchronously a sequence w/o init', async () => {
+        const asyncGenerator = createAsyncGeneratorFor([1, 2, 3, 4, 5])
+        const gs = asyncGenSequence(asyncGenerator);
+        const result = await gs.reduceAsync((a, v) => a + v);
+        expect(result).toEqual(15);
+    });
+
+    test('tests reducing asynchronously a sequence with init', async () => {
+        const asyncGenerator = createAsyncGeneratorFor([1, 2, 3, 4, 5])()
+        const gs = asyncGenSequence(asyncGenerator);
+        const result = await gs.reduceAsync(async (a, v) => a + v, Promise.resolve(10));
+        expect(result).toEqual(25);
+    });
+
+    test('tests async iterator attribute', async () => {
+        const asyncGenerator = createAsyncGeneratorFor([1, 2, 3])
+        const asyncIterator = asyncGenSequence(asyncGenerator)[Symbol.asyncIterator]();
+        const result1 = await asyncIterator.next()
+        const result2 = await asyncIterator.next()
+        const result3 = await asyncIterator.next()
+        const result4 = await asyncIterator.next()
+        expect(result1.value).toEqual(1);
+        expect(result1.done).toEqual(false);
+        expect(result2.value).toEqual(2);
+        expect(result3.done).toEqual(false);
+        expect(result3.value).toEqual(3);
+        expect(result3.done).toEqual(false);
+        expect(result4.value).toEqual(undefined);
+        expect(result4.done).toEqual(true);
+    });
+});
+
+function createAsyncGeneratorFor<T>(array: T[]) {
+    return async function* asyncGenerator() {
+        for (const i of array) {
+            yield i
+        }
+    }
+}

--- a/src/AsyncGenSequence.ts
+++ b/src/AsyncGenSequence.ts
@@ -1,0 +1,8 @@
+import { AsyncSequence, AsyncGenIterable } from './types';
+import { ImplAsyncSequence } from './ImplAsyncSequence';
+
+export function asyncGenSequence<T>(i: AsyncGenIterable<T>): AsyncSequence<T>;
+export function asyncGenSequence<T>(i: () => AsyncGenIterable<T>): AsyncSequence<T>;
+export function asyncGenSequence<T>(i: AsyncGenIterable<T> | (() => AsyncGenIterable<T>)): AsyncSequence<T> {
+    return new ImplAsyncSequence(i);
+}

--- a/src/GenSequence.test.ts
+++ b/src/GenSequence.test.ts
@@ -58,6 +58,20 @@ describe('GenSequence Tests', () => {
         expect(result).toEqual(values);
     });
 
+    test('tests reducing asynchronously a sequence w/o init', async () => {
+        const values = [1, 2, 3, 4, 5].map(x => Promise.resolve<number>(x));
+        const gs = genSequence(values[Symbol.iterator]());
+        const result = await gs.reduceAsync((a, v) => a + v);
+        expect(result).toEqual(15);
+    });
+
+    test('tests reducing asynchronously a sequence with init', async () => {
+        const values = [1, 2, 3, 4, 5].map(x => Promise.resolve<number>(x));
+        const gs = genSequence(values[Symbol.iterator]());
+        const result = await gs.reduceAsync(async (a, v) => a + v, Promise.resolve(10));
+        expect(result).toEqual(25);
+    });
+
     test('tests reducing a sequence to a sequence', () => {
         const values = [1, 2, 3, 4, 5];
         const gs = genSequence(values);

--- a/src/GenSequence.test.ts
+++ b/src/GenSequence.test.ts
@@ -60,13 +60,13 @@ describe('GenSequence Tests', () => {
 
     test('tests reducing asynchronously a sequence w/o init', async () => {
         const values = [1, 2, 3, 4, 5].map(x => Promise.resolve<number>(x));
-        const gs = genSequence(values[Symbol.iterator]());
+        const gs = genSequence(values);
         const result = await gs.reduceAsync((a, v) => a + v);
-        expect(result).toEqual(15);
+        expect(result).toEqual(16);
     });
 
     test('tests reducing asynchronously a sequence with init', async () => {
-        const values = [1, 2, 3, 4, 5].map(x => Promise.resolve<number>(x));
+        const values = [1, 2, 3, 4, 5];
         const gs = genSequence(values[Symbol.iterator]());
         const result = await gs.reduceAsync(async (a, v) => a + v, Promise.resolve(10));
         expect(result).toEqual(25);

--- a/src/GenSequence.ts
+++ b/src/GenSequence.ts
@@ -2,7 +2,7 @@ import { Sequence, GenIterable } from './types';
 import { toIterableIterator } from './util/util';
 import { ImplSequence } from './ImplSequence';
 
-export { Sequence, GenIterable } from './types';
+export { Sequence, GenIterable, AsyncGenIterable } from './types';
 export { toIterableIterator } from './util/util';
 
 export interface SequenceCreator<T> {

--- a/src/ImplAsyncSequence.ts
+++ b/src/ImplAsyncSequence.ts
@@ -1,0 +1,19 @@
+import { AsyncLazyIterable, AsyncSequence, ThenArg, AsyncIterableLike } from './types';
+import { reduceAsyncForAsyncIterator } from './operators';
+
+export class ImplAsyncSequence<T> implements AsyncSequence<T> {
+    constructor(private i: AsyncLazyIterable<T>) {
+    }
+
+    private get iter() {
+        return (typeof this.i === "function") ? this.i() : this.i;
+    }
+
+    [Symbol.asyncIterator]() {
+        return this.iter[Symbol.asyncIterator]();
+    }
+
+    reduceAsync<U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U> | Promise<ThenArg<U>>, initialValue?: ThenArg<U>): Promise<ThenArg<U>> {
+        return reduceAsyncForAsyncIterator<T, U>(fnReduceAsync, initialValue)(this.iter as AsyncIterableLike<ThenArg<T>>);
+    }
+}

--- a/src/ImplSequence.ts
+++ b/src/ImplSequence.ts
@@ -1,5 +1,5 @@
-import { Sequence, GenIterable, Maybe, LazyIterable, ChainFunction } from './types';
-import { filter, skip, take, concat, concatMap, combine, map, scan, all, any, count, first, forEach, max, min, reduce, pipe } from './operators';
+import { Sequence, GenIterable, Maybe, LazyIterable, ChainFunction, ThenArg, IterableLike } from './types';
+import { filter, skip, take, concat, concatMap, combine, map, scan, all, any, count, first, forEach, max, min, reduce, reduceAsync, pipe } from './operators';
 import { toIterableIterator } from './util/util';
 
 export class ImplSequence<T> implements Sequence<T> {
@@ -118,6 +118,10 @@ export class ImplSequence<T> implements Sequence<T> {
 
     reduce<U>(fnReduce: (prevValue: U, curValue: T, curIndex: number) => U, initValue?: U) {
         return reduce<T, U>(fnReduce, initValue!)(this.iter);
+    }
+
+    reduceAsync<U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U> | Promise<ThenArg<U>>, initialValue?: ThenArg<U>): Promise<ThenArg<U>> {
+        return reduceAsync<T, U>(fnReduceAsync, initialValue)(this.iter as IterableLike<ThenArg<T>>);
     }
 
     reduceToSequence<U>(

--- a/src/ImplSequenceBuilder.test.ts
+++ b/src/ImplSequenceBuilder.test.ts
@@ -1,5 +1,5 @@
 import { ImplSequenceBuilder } from './ImplSequenceBuilder';
-import { map } from './operators';
+import { map, filter } from './operators';
 import { scanMap } from './operators/operatorsBase';
 import { builder } from './builder';
 
@@ -32,10 +32,12 @@ describe('Verify ImplSequenceBuilder', () => {
 
     test('Test pipe', () => {
         const fn = (a: number) => a * 2;
-        const a = [1, 2, 3];
-        const b = getBuilder().pipe(map(fn));
+        const fn2 = (a: number) => a > 10;
+        const fn3 = (a: number) => a > 12;
+        const a = [1, 2, 3, 4];
+        const b = getBuilder().pipe(map(fn), map(fn), filter(fn2), filter(fn3));
         const i = b.build(a);
-        expect([...i]).toEqual(a.map(fn));
+        expect([...i]).toEqual([16]);
     });
 
     test('Test filter', () => {

--- a/src/ImplSequenceBuilder.ts
+++ b/src/ImplSequenceBuilder.ts
@@ -13,8 +13,8 @@ export class ImplSequenceBuilder<S, T = S> implements SequenceBuilder<S, T> {
         return new ImplSequence(i).pipe(pipe.apply<unknown, any, ChainFunction<S, T>>(null, this.operators));
     }
 
-    pipe<U>(fn: ChainFunction<T, U>): SequenceBuilder<S, U> {
-        return new ImplSequenceBuilder<S, U>([...this.operators, fn] as any[]);
+    pipe<U>(...fns: ChainFunction<T, U>[]): SequenceBuilder<S, U> {
+        return new ImplSequenceBuilder<S, U>([...this.operators, ...fns] as any[]);
     }
 
     //// Filters

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './GenSequence';
+export * from './AsyncGenSequence';
 export { Sequence, LazyIterable, IterableLike, SequenceBuilder } from './types';
 export * from './builder';
 

--- a/src/operators/operators.test.ts
+++ b/src/operators/operators.test.ts
@@ -89,4 +89,19 @@ describe('Validate Operators', () => {
         const samples = [1, 2, 3, 4, 5];
         expect([...fn(samples)]).toEqual(samples.map(n => n * 100 + 101));
     });
+
+    test('pipe returns the item if a function is falsy', () => {
+        // as types is just runtime sometimes the function can be null
+        const fn = pipe(
+            0 as any,
+            null as any,
+            undefined as any,
+            false as any,
+            NaN as any,
+            fnAddOne,
+        );
+        const samples = [1, 2];
+
+        expect([...fn(samples)]).toEqual([2, 3]);
+    })
 });

--- a/src/operators/operators.ts
+++ b/src/operators/operators.ts
@@ -1,6 +1,6 @@
 import * as op from './operatorsBase';
 
-import { Maybe, IterableLike, ChainFunction, ReduceFunction, ThenArg, ReduceAsyncFunction } from '../types';
+import { Maybe, IterableLike, ChainFunction, ReduceFunction, ThenArg, ReduceAsyncFunction, AsyncIterableLike, ReduceAsyncFunctionForAsyncIterator } from '../types';
 
 /**
  * Operators used by Sequence
@@ -100,6 +100,12 @@ export function reduceAsync<T, U>(fnReduceAsync: (previousValue: ThenArg<U>, cur
 export function reduceAsync<T>(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, initialValue?: ThenArg<T>): ReduceAsyncFunction<T, Promise<ThenArg<T>>>
 export function reduceAsync<T>(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, initialValue?: ThenArg<T>): ReduceAsyncFunction<T, Promise<ThenArg<T>>> {
     return (i: IterableLike<ThenArg<T>>) => op.reduceAsync(fnReduceAsync, i, initialValue);
+}
+
+export function reduceAsyncForAsyncIterator<T, U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U> | Promise<ThenArg<U>>, initialValue?: ThenArg<U>): ReduceAsyncFunctionForAsyncIterator<T, Promise<ThenArg<U>>>;
+export function reduceAsyncForAsyncIterator<T>(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, initialValue?: ThenArg<T>): ReduceAsyncFunctionForAsyncIterator<T, Promise<ThenArg<T>>>
+export function reduceAsyncForAsyncIterator<T>(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, initialValue?: ThenArg<T>): ReduceAsyncFunctionForAsyncIterator<T, Promise<ThenArg<T>>> {
+    return (i: AsyncIterableLike<ThenArg<T>>) => op.reduceAsyncForAsyncIterator(fnReduceAsync, i, initialValue);
 }
 
 export type PipeFunction<T, U = T> = ChainFunction<T, U>;

--- a/src/operators/operators.ts
+++ b/src/operators/operators.ts
@@ -1,6 +1,6 @@
 import * as op from './operatorsBase';
 
-import { Maybe, IterableLike, ChainFunction, ReduceFunction } from '../types';
+import { Maybe, IterableLike, ChainFunction, ReduceFunction, ThenArg, ReduceAsyncFunction } from '../types';
 
 /**
  * Operators used by Sequence
@@ -94,6 +94,12 @@ export function reduce<T>(fnReduce: (prevValue: T, curValue: T, curIndex: number
 export function reduce<T>(fnReduce: (prevValue: T, curValue: T, curIndex: number) => T, initialValue: Maybe<T>): ReduceFunction<T, Maybe<T>>;
 export function reduce<T>(fnReduce: (prevValue: T, curValue: T, curIndex: number) => T, initialValue: Maybe<T>): ReduceFunction<T, Maybe<T>> {
     return (i: IterableLike<T>) => op.reduce(fnReduce, initialValue, i);
+}
+
+export function reduceAsync<T, U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U>| Promise<ThenArg<U>>, initialValue?: ThenArg<U>): ReduceAsyncFunction<T, Promise<ThenArg<U>>>;
+export function reduceAsync<T>(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, initialValue?: ThenArg<T>): ReduceAsyncFunction<T, Promise<ThenArg<T>>>
+export function reduceAsync<T>(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, initialValue?: ThenArg<T>): ReduceAsyncFunction<T, Promise<ThenArg<T>>> {
+    return (i: IterableLike<ThenArg<T>>) => op.reduceAsync(fnReduceAsync, i, initialValue);
 }
 
 export type PipeFunction<T, U = T> = ChainFunction<T, U>;

--- a/src/operators/operatorsBase.test.ts
+++ b/src/operators/operatorsBase.test.ts
@@ -2,7 +2,6 @@ import * as op from './operatorsBase';
 import { toIterator } from '../util/util';
 
 describe('Tests Operators', () => {
-
     test('test the curring part of GS.map', () => {
         const fnMap = op.map((a: number) => 2 * a);
         expect(fnMap).toBeInstanceOf(Function);

--- a/src/operators/operatorsBase.ts
+++ b/src/operators/operatorsBase.ts
@@ -1,4 +1,4 @@
-import { Maybe, IterableLike, ThenArg } from '../types';
+import { Maybe, IterableLike, ThenArg, AsyncIterableLike } from '../types';
 
 /**
  * Operators used by Sequence
@@ -193,6 +193,25 @@ export async function reduceAsync<T>(fnReduceAsync: (previosValue: ThenArg<T>, c
     if (initialValue === undefined) {
         index = 1;
         const r = await i[Symbol.iterator]().next();
+        initialValue = r.value;
+    }
+    let previosValue = await initialValue as ThenArg<T>;
+
+    for await (const t of i) {
+        const nextValue = await fnReduceAsync(previosValue, t, index);
+        previosValue = nextValue;
+        index += 1;
+    }
+    return previosValue;
+}
+
+export async function reduceAsyncForAsyncIterator<T, U>(fnReduceAsync: (previosValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U> | Promise<ThenArg<U>>, i: AsyncIterableLike<ThenArg<T>>, initialValue?: ThenArg<U>): Promise<ThenArg<U>>;
+export async function reduceAsyncForAsyncIterator<T>(fnReduceAsync: (previosValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, i: AsyncIterableLike<ThenArg<T>>, initialValue?: ThenArg<T>): Promise<ThenArg<T>>;
+export async function reduceAsyncForAsyncIterator<T>(fnReduceAsync: (previosValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => Promise<ThenArg<T>>, i: AsyncIterableLike<ThenArg<T>>, initialValue?: ThenArg<T>): Promise<ThenArg<T>> {
+    let index = 0;
+    if (initialValue === undefined) {
+        index = 1;
+        const r = await i[Symbol.asyncIterator]().next();
         initialValue = r.value;
     }
     let previosValue = await initialValue as ThenArg<T>;

--- a/src/operators/operatorsBase.ts
+++ b/src/operators/operatorsBase.ts
@@ -1,4 +1,4 @@
-import { Maybe, IterableLike } from '../types';
+import { Maybe, IterableLike, ThenArg } from '../types';
 
 /**
  * Operators used by Sequence
@@ -184,6 +184,25 @@ export function reduce<T>(fnReduce: (prevValue: T, curValue: T, curIndex: number
         index += 1;
     }
     return prevValue;
+}
+
+export async function reduceAsync<T, U>(fnReduceAsync: (previosValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U> | Promise<ThenArg<U>>, i: IterableLike<ThenArg<T>>, initialValue?: ThenArg<U>): Promise<ThenArg<U>>;
+export async function reduceAsync<T>(fnReduceAsync: (previosValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T> | Promise<ThenArg<T>>, i: IterableLike<ThenArg<T>>, initialValue?: ThenArg<T>): Promise<ThenArg<T>>;
+export async function reduceAsync<T>(fnReduceAsync: (previosValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => Promise<ThenArg<T>>, i: IterableLike<ThenArg<T>>, initialValue?: ThenArg<T>): Promise<ThenArg<T>> {
+    let index = 0;
+    if (initialValue === undefined) {
+        index = 1;
+        const r = await i[Symbol.iterator]().next();
+        initialValue = r.value;
+    }
+    let previosValue = await initialValue as ThenArg<T>;
+
+    for await (const t of i) {
+        const nextValue = await fnReduceAsync(previosValue, t, index);
+        previosValue = nextValue;
+        index += 1;
+    }
+    return previosValue;
 }
 
 //// Utilities

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type Maybe<T> = T | undefined;
+export type ThenArg<T> = T extends Promise<infer U> ? U : T
 
 export interface IterableLike<T> {
     [Symbol.iterator](): Iterator<T> | IterableIterator<T>;
@@ -10,6 +11,7 @@ export type LazyIterable<T> = (() => IterableLike<T>) | IterableLike<T>;
 
 export type ChainFunction<T, U = T> = (i: IterableLike<T>) => IterableLike<U>;
 export type ReduceFunction<T, U = T> = (i: IterableLike<T>) => U;
+export type ReduceAsyncFunction<T, U = T> = (i: IterableLike<ThenArg<T>>) => U;
 
 export interface Sequence<T> extends IterableLike<T> {
     next(): IteratorResult<T>;
@@ -45,6 +47,10 @@ export interface Sequence<T> extends IterableLike<T> {
     /** reduce function see Array.reduce */
     reduce(fnReduce: (previousValue: T, currentValue: T, currentIndex: number) => T): Maybe<T>;
     reduce<U>(fnReduce: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): U;
+    reduceAsync(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T>): Promise<ThenArg<T>>;
+    reduceAsync(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => Promise<ThenArg<T>>): Promise<ThenArg<T>>;
+    reduceAsync<U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U>, initialValue: U): Promise<ThenArg<U>>;
+    reduceAsync<U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => Promise<ThenArg<U>>, initialValue: U): Promise<ThenArg<U>>;
     reduceToSequence<U, V extends GenIterable<U>>(fnReduce: (previousValue: V, currentValue: T, currentIndex: number) => V, initialValue: V): Sequence<U>;
     reduceToSequence<U>(fnReduce: (previousValue: GenIterable<U>, currentValue: T, currentIndex: number) => GenIterable<U>, initialValue: GenIterable<U>): Sequence<U>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,4 +86,13 @@ export interface SequenceBuilder<S, T = S> {
 
     //// Pipe
     pipe<U>(fn: ChainFunction<T, U>): SequenceBuilder<S, U>;
+
+
+    pipe<U>(fn0: ChainFunction<T, U>): SequenceBuilder<S, U>;
+    pipe<T1, U>(fn0: ChainFunction<T, T1>, fn1: ChainFunction<T1, U>): SequenceBuilder<S, U>;
+    pipe<T1, T2, U>(fn0: ChainFunction<T, T1>, fn1: ChainFunction<T1, T2>, fn2: ChainFunction<T2, U>): SequenceBuilder<S, U>;
+    pipe<T1, T2, T3, U>(fn0: ChainFunction<T, T1>, fn1: ChainFunction<T1, T2>, fn2: ChainFunction<T2, T3>, fn3: ChainFunction<T3, U>): SequenceBuilder<S, U>;
+    pipe<T1, T2, T3, T4, U>(fn0: ChainFunction<T, T1>, fn1: ChainFunction<T1, T2>, fn2: ChainFunction<T2, T3>, fn3: ChainFunction<T3, T4>, fn4: ChainFunction<T4, U>): SequenceBuilder<S, U>;
+    pipe<T1, T2, T3, T4, T5, U>(fn0: ChainFunction<T, T1>, fn1: ChainFunction<T1, T2>, fn2: ChainFunction<T2, T3>, fn3: ChainFunction<T3, T4>, fn4: ChainFunction<T4, T5>, fn5: ChainFunction<T5, U>): SequenceBuilder<S, U>;
+    pipe<U>(...fns: ChainFunction<T, U>[]): SequenceBuilder<S, U>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,13 +5,20 @@ export interface IterableLike<T> {
     [Symbol.iterator](): Iterator<T> | IterableIterator<T>;
 }
 
+export interface AsyncIterableLike<T> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+}
+
 export interface GenIterable<T> extends IterableLike<T> {}
+export interface AsyncGenIterable<T> extends AsyncIterableLike<T> {}
 
 export type LazyIterable<T> = (() => IterableLike<T>) | IterableLike<T>;
+export type AsyncLazyIterable<T> = (() => AsyncIterableLike<T>) | AsyncIterableLike<T>;
 
 export type ChainFunction<T, U = T> = (i: IterableLike<T>) => IterableLike<U>;
 export type ReduceFunction<T, U = T> = (i: IterableLike<T>) => U;
 export type ReduceAsyncFunction<T, U = T> = (i: IterableLike<ThenArg<T>>) => U;
+export type ReduceAsyncFunctionForAsyncIterator<T, U = T> = (i: AsyncIterableLike<ThenArg<T>>) => U;
 
 export interface Sequence<T> extends IterableLike<T> {
     next(): IteratorResult<T>;
@@ -68,6 +75,13 @@ export interface Sequence<T> extends IterableLike<T> {
     //// Cast
     toArray(): T[];
     toIterable(): IterableIterator<T>;
+}
+
+export interface AsyncSequence<T> extends AsyncIterableLike<T> {
+    reduceAsync(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<T>): Promise<ThenArg<T>>;
+    reduceAsync(fnReduceAsync: (previousValue: ThenArg<T>, currentValue: ThenArg<T>, currentIndex: number) => Promise<ThenArg<T>>): Promise<ThenArg<T>>;
+    reduceAsync<U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => ThenArg<U>, initialValue: U): Promise<ThenArg<U>>;
+    reduceAsync<U>(fnReduceAsync: (previousValue: ThenArg<U>, currentValue: ThenArg<T>, currentIndex: number) => Promise<ThenArg<U>>, initialValue: U): Promise<ThenArg<U>>;
 }
 
 export interface SequenceBuilder<S, T = S> {


### PR DESCRIPTION
it can be used in two cases.

When the reducer function is async, when you want to chain the promises, executing on by one.
```!#javascript
ids = ['1','2','3'](Symbol.iterator)()
async function sumTotalOfVotes(sum: number, id: string) { ... }

const totalOfVotes = await genSequence(ids).reduceAsync(sumTotalOfVotes, 0)
```

or dealing with async generator

```
async function* getCommentsUntil(date: Date) { }
function concatNeededComments() {} // concatNeededComments could be async as well

const gs = genSequence(getCommentsUntil(new Date()))
const totalOfVotes = gs.reduceAsync(getCommentsINeed, previousCommentsPromise)
```

